### PR TITLE
Step 11 讓任務以建立時間排序並且在 tasks_spec 中增加此功能的測試

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -5,7 +5,7 @@ class TasksController < ApplicationController
   before_action :find_task, only: %i[show edit update destroy]
 
   def index
-    @tasks = Task.all
+    @tasks = Task.order(created_at: :asc)
   end
 
   def show; end

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -36,12 +36,23 @@ RSpec.describe 'Tasks' do
   end
 
   describe '#index' do
-    let!(:task) { create(:task) }
+    let!(:task_created_one_day_ago) { create(:task, created_at: 1.day.ago) }
+    let!(:task_created_two_days_ago) { create(:task, created_at: 2.days.ago) }
+    let!(:task_created_three_days_ago) { create(:task, created_at: 3.days.ago) }
 
-    before { visit task_path(task) }
+    before { visit tasks_path }
 
-    it { is_expected.to have_text(task.name) }
-    it { is_expected.to have_text(task.content) }
+    it 'displays the task created three days ago before the task created two days ago' do
+      expect(page.body.index(task_created_three_days_ago.name)).to be < page.body.index(task_created_two_days_ago.name)
+    end
+
+    it 'displays the task created two days ago before the task created one day ago' do
+      expect(page.body.index(task_created_two_days_ago.name)).to be < page.body.index(task_created_one_day_ago.name)
+    end
+
+    it { is_expected.to have_text(task_created_one_day_ago.name) }
+    it { is_expected.to have_text(task_created_two_days_ago.name) }
+    it { is_expected.to have_text(task_created_three_days_ago.name) }
   end
 
   describe '#update' do

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -36,23 +36,25 @@ RSpec.describe 'Tasks' do
   end
 
   describe '#index' do
-    let!(:task_created_one_day_ago) { create(:task, created_at: 1.day.ago) }
-    let!(:task_created_two_days_ago) { create(:task, created_at: 2.days.ago) }
-    let!(:task_created_three_days_ago) { create(:task, created_at: 3.days.ago) }
+    let!(:tasks) do
+      3.downto(1).map do |i|
+        travel_to(i.days.ago) { create(:task) }
+      end
+    end
 
     before { visit tasks_path }
 
-    it 'displays the task created three days ago before the task created two days ago' do
-      expect(page.body.index(task_created_three_days_ago.name)).to be < page.body.index(task_created_two_days_ago.name)
+    it 'displays tasks in ascending order of creation date' do
+      tasks.each_cons(2) do |task_earlier, task_later|
+        expect(page.body.index(task_earlier.name)).to be < page.body.index(task_later.name)
+      end
     end
 
-    it 'displays the task created two days ago before the task created one day ago' do
-      expect(page.body.index(task_created_two_days_ago.name)).to be < page.body.index(task_created_one_day_ago.name)
+    it 'displays all tasks' do
+      tasks.each do |task|
+        expect(page).to have_text(task.name)
+      end
     end
-
-    it { is_expected.to have_text(task_created_one_day_ago.name) }
-    it { is_expected.to have_text(task_created_two_days_ago.name) }
-    it { is_expected.to have_text(task_created_three_days_ago.name) }
   end
 
   describe '#update' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -66,4 +66,5 @@ RSpec.configure do |config|
   # config.filter_gems_from_backtrace("gem name")
   config.include FactoryBot::Syntax::Methods
   config.include ActionView::RecordIdentifier, type: :feature
+  config.include ActiveSupport::Testing::TimeHelpers
 end


### PR DESCRIPTION
增加以下一個功能：

- 任務在 index 以 created_at 遞增排序

增加以下一個測試：

- 測試建立三個任務，確認是否有以建立時間較早的派在前面，較晚的排在後面